### PR TITLE
Use python from env in example script

### DIFF
--- a/client/examples/cycle-cards.py
+++ b/client/examples/cycle-cards.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 import removinator
 import subprocess


### PR DESCRIPTION
This makes the cycle-cards example script use python from the env
instead of harcoding the location.  This allows a virtualenv to be
easily used.