### PR TITLE
Strip out debug output when parsing for JSON status

### DIFF
--- a/client/removinator/removinator.py
+++ b/client/removinator/removinator.py
@@ -172,7 +172,14 @@ class Removinator:
         """
 
         self.send_command('STA')
-        return json.loads(self.last_response.rstrip())
+
+        # Strip out any debug output responses before
+        # attempting to parse the JSON status.
+        for resp_line in self.last_response.splitlines():
+            if (not resp_line.startswith('[DBG]')):
+                break
+
+        return json.loads(resp_line)
 
     def send_command(self, command):
         """


### PR DESCRIPTION
The get_status() method in the client library throws an exception
when trying to parse the JSON status when debug is enabled on a
controller.  We need to ignore DBG lines in the response before
attempting to parse the status.