### PR TITLE
Add smart card slot locking functionality

### DIFF
--- a/client/removinator/__init__.py
+++ b/client/removinator/__init__.py
@@ -4,23 +4,30 @@ def cli():
     import argparse
     from removinator import removinator
 
+    valid_commands = [
+        'insert_card',
+        'remove_card',
+        'get_status',
+    ]
+
     parser = argparse.ArgumentParser()
-    parser.add_argument('command', nargs='*', default=['get_status'])
+    subparsers = parser.add_subparsers(dest='command')
+
+    parser_insert_card = subparsers.add_parser('insert_card')
+    parser_insert_card.add_argument('slot', type=int)
+
+    subparsers.add_parser('remove_card')
+    subparsers.add_parser('get_status')
+
     args = parser.parse_args()
 
     conn = removinator.Removinator()
 
-    if args.command[0] == 'insert_card':
-        if len(args.command) != 2:
-            print('insert_card command must specify ONE slot number')
-        else:
-            print('Switching slot to {}'.format(args.command[1]))
-            conn.insert_card(int(args.command[1]))
-    elif args.command[0] == 'remove_card':
+    if args.command == 'insert_card':
+        print('Switching slot to {}'.format(args.slot))
+        conn.insert_card(args.slot)
+    elif args.command == 'remove_card':
         print('Removing card from current slot')
         conn.remove_card()
-    elif args.command[0] == 'get_status':
-        print(conn.get_status())
     else:
-        print('Invalid command selected...running get_status instead')
         print(conn.get_status())

--- a/client/removinator/__init__.py
+++ b/client/removinator/__init__.py
@@ -7,6 +7,8 @@ def cli():
     valid_commands = [
         'insert_card',
         'remove_card',
+        'lock_card',
+        'unlock_card',
         'get_status',
     ]
 
@@ -15,6 +17,11 @@ def cli():
 
     parser_insert_card = subparsers.add_parser('insert_card')
     parser_insert_card.add_argument('slot', type=int)
+
+    parser_lock_card = subparsers.add_parser('lock_card')
+    parser_lock_card.add_argument('slot', type=int)
+    parser_unlock_card = subparsers.add_parser('unlock_card')
+    parser_unlock_card.add_argument('slot', type=int)
 
     subparsers.add_parser('remove_card')
     subparsers.add_parser('get_status')
@@ -29,5 +36,11 @@ def cli():
     elif args.command == 'remove_card':
         print('Removing card from current slot')
         conn.remove_card()
+    elif args.command == 'lock_card':
+        print('Locking card slot {}'.format(args.slot))
+        conn.lock_card(args.slot)
+    elif args.command == 'unlock_card':
+        print('Unlocking card slot {}'.format(args.slot))
+        conn.unlock_card(args.slot)
     else:
         print(conn.get_status())

--- a/firmware/removinator/removinator.ino
+++ b/firmware/removinator/removinator.ino
@@ -47,8 +47,10 @@
 #define LOG_DBG_PREFIX "[DBG] "
 
 // Constants
-const byte display_digits[] = { 0x84, 0xD7, 0xA1, 0x91, 0xD2,
-                                0x98, 0x88, 0xD5, 0x80, 0x90 };
+unsigned const char display_digits[] = {
+    0x84, 0xD7, 0xA1, 0x91, 0xD2,
+    0x98, 0x88, 0xD5, 0x80, 0x90,
+};
 const int mux_en_pin = 2;
 const int mux_a0_pin = 3;
 const int mux_a1_pin = 4;
@@ -60,17 +62,17 @@ const int reader_switch_pin = 8;
 // Globals
 char command[CMD_MAX_LEN + 1];
 int inserted_card = 0;
-boolean debug = false;
+bool debug = false;
 
 // Function prototypes
 void setup();
 void loop();
 int getCommand();
 int insertCard(int card);
-void removeCard(boolean print_response);
+void removeCard(bool print_response);
 int updateDisplay(int digit);
 void printCardStatus();
-byte getCardStatus(int card);
+unsigned char getCardStatus(int card);
 void toggleDebug();
 void debug_print(String msg);
 void usage();
@@ -339,7 +341,7 @@ int insertCard(int card)
 //                      print a response if the user explicitly sent a
 //                      command to remove the card.
 //
-void removeCard(boolean print_response)
+void removeCard(bool print_response)
 {
     digitalWrite(reader_switch_pin, HIGH);
     digitalWrite(mux_en_pin, LOW);
@@ -443,7 +445,7 @@ void printCardStatus()
 {
     int i = 0;
     int need_comma = 0;
-    byte status = 0;
+    unsigned char status = 0;
     String status_json = "{\"current\":";
 
     // Add the currently inserted card to the status.
@@ -488,7 +490,7 @@ void printCardStatus()
 //          card sockets.
 //
 // Returns:
-//   status - A byte indicating the status for the requested
+//   status - A char indicating the status for the requested
 //            card sockets.  If a single card socket is being
 //            checked, this byte will be 0x01 if a card is
 //            inserted, and 0x00 if the socket is empty.  If
@@ -498,9 +500,9 @@ void printCardStatus()
 //            represented by the LSB, and card socket 8 is
 //            represented by the MSB.
 //
-byte getCardStatus(int card)
+unsigned char getCardStatus(int card)
 {
-    byte status = 0;
+    unsigned char status = 0;
 
     // Start a SPI transaction with a max speed of 20MHz.
     SPI.beginTransaction(SPISettings(20000000, MSBFIRST, SPI_MODE0));


### PR DESCRIPTION
As the firmware comment says,
```
// lockCard()
//
// Locks the specified card slot, making another lock operation on the same slot
// fail if attempted. An unlock must be issued on the slot to restore successful
// locking functionality.
//
// The idea is to limit accidental use in unexpected scenarios, bricking cards
// by a client entering a wrong password repeatedly due to an automation bug.
// The client can lock a slot before using it and unlock it only if everything
// went smoothly. Any infrastructure crash or automation bug should leave it
// locked, letting a human investigate the situation and manually reset the card
// password attempts using an external card reader and a correct password.
```
this is mainly to prevent bricking cards with a limited wrong-passphrase retry count.

The EEPROM wear leveling code is not perfect, but good enough for basically unlimited endurance. Atmel AVR MCUs can handle ~100k guaranteed writes on each byte, and with tests running 24/7, 100 runs a day, it could get there in ~3 years. Wear-leveling it increases that by 512/2=256 times, or ~768 years.  
Not every ATmega has 1024 bytes of EEPROM, so I wanted to leave this at 512 instead of the 32U4's (Micro) 1024 bytes. Honestly, it doesn't matter in practice.

Dealing with "indexed commands" was done via macros as the rest of the code seemed to use functions for "bigger things", I didn't see utility "inlined" one-liners in the file. To keep it small, self-contained and fast (ability to use compile-time `sizeof()` rather than `strlen()`), and also given that `command` is a global variable, I used macros.  
In general, I have tried to make the new code match the old where possible, sometimes slightly altering the old code as well, but overall keeping the changeset as small as possible.

The best way to review this PR is probably going commit-by-commit, as that helps constrain the scope of each change in one's mind. Also, some commits have extra description / explanation.

---

I tested most of the functionality via the serial line directly (`screen /dev/ttyACM0 115200`), but I did try to make the python CLI robust as well.
```
$ rminator 
{'current': 0, 'present': [1, 2, 4], 'locked': []}
$ rminator insert_card 1
Switching slot to 1
$ rminator 
{'current': 1, 'present': [1, 2, 4], 'locked': []}
$ rminator insert_card 2
Switching slot to 2
$ rminator 
{'current': 2, 'present': [1, 2, 4], 'locked': []}
$ rminator lock_card 1
Locking card slot 1
$ rminator 
{'current': 2, 'present': [1, 2, 4], 'locked': [1]}
$ rminator insert_card 1
Switching slot to 1
...
removinator.removinator.LockedError: Slot 1 is locked
$ rminator lock_card 1
Locking card slot 1
...
removinator.removinator.LockedError: Slot 1 is already locked
$ rminator unlock_card 1
Unlocking card slot 1
$ rminator 
{'current': 2, 'present': [1, 2, 4], 'locked': []}
$ rminator insert_card 1
Switching slot to 1
$ rminator 
{'current': 1, 'present': [1, 2, 4], 'locked': []}
```